### PR TITLE
add meta tags title description for link previews

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,15 @@
 
 <head>
   <title>RPG Talk</title>
+  <meta name="title" content="RPG Talk">
+  <meta name="description" content="An inclusive Discord community to chat about all your favorite role-playing games!">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://rpg-talk.com/">
+  <meta property="og:title" content="RPG Talk">
+  <meta property="og:description" content="An inclusive Discord community to chat about all your favorite role-playing games!">
+  <meta property="twitter:url" content="https://rpg-talk.com/">
+  <meta property="twitter:title" content="RPG Talk">
+  <meta property="twitter:description" content="An inclusive Discord community to chat about all your favorite role-playing games!">
   <link rel="stylesheet" href="https://bootswatch.com/3/flatly/bootstrap.min.css">
   <link rel="stylesheet" href="jumbotron-narrow.css" />
   <script>


### PR DESCRIPTION
As talked about on #software_dev, I also have a banner that could be included as a meta image, but this is a simpler change. Adds some preview information for when people share a link to https://rpg-talk.com on any social media, Discord itself, etc.